### PR TITLE
enhancement: exception customizer as thread local

### DIFF
--- a/jareto-demo/src/main/java/at/co/svc/bs/BeanService.java
+++ b/jareto-demo/src/main/java/at/co/svc/bs/BeanService.java
@@ -11,6 +11,9 @@ import at.co.svc.jareto.client.meta.ClientRequestHeaders;
 import at.co.svc.jareto.client.meta.ClientResponse;
 import at.co.svc.jareto.common.exceptions.AppException;
 import at.co.svc.jareto.common.exceptions.AppRuntimeException;
+import at.co.svc.jareto.common.exceptions.IAppException;
+import at.co.svc.jareto.server.exceptions.IServiceExceptionCustomizer;
+import at.co.svc.jareto.server.exceptions.WebApplicationExceptionFactory;
 import at.co.svc.jareto.server.meta.ServiceResponseBuilder;
 
 /**
@@ -21,15 +24,15 @@ public class BeanService implements IBeanService {
   @Inject
   @RestClient
   private IBeanServiceForClient _client;
-  
+
   // you could also add a HeaderParam as explicit method param if you want to make it explicit
   // to the client (example see below)
   @HeaderParam(IBeanService.X_TEST_HEADER_FROM_CLIENT)
   private String _testHeader;
-  
+
   @Inject
   private ServiceResponseBuilder _responseBuilder;
-  
+
   @Override
   public String ping(Integer desiredStatus) {
     // reflect the client header back via server header
@@ -49,7 +52,19 @@ public class BeanService implements IBeanService {
   public void exMapped() throws AppException {
     throw BeanExceptionFactory.createBeanException();
   }
-  
+
+  @Override
+  public void exMappedCustomized() throws AppException {
+    WebApplicationExceptionFactory.registerCustomizerThreadLocal(new IServiceExceptionCustomizer() {
+      @Override
+      public void appException(IAppException e) {
+        e.getData().setCode(e.getData().getCode() + "c");
+        e.getData().setText(e.getData().getText() + " customized");
+      }
+    });
+    throw BeanExceptionFactory.createBeanException();
+  }
+
   @Override
   public void exMappedRte() throws AppRuntimeException {
     throw BeanExceptionFactory.createBeanRuntimeException();
@@ -57,21 +72,21 @@ public class BeanService implements IBeanService {
 
   @Override
   public String cascade(Integer desiredStatus) {
-    
+
     // pass through the incoming request header
     ClientRequestHeaders.addHeader(IBeanService.X_TEST_HEADER_FROM_CLIENT, _testHeader);
-    
+
     String ping = _client.ping(desiredStatus);
-    
+
     // pass through the incoming response header
     _responseBuilder.get().header(IBeanService.X_TEST_HEADER_FROM_SERVER,
         ClientResponse.CONTEXT.get().getHeaderString(IBeanService.X_TEST_HEADER_FROM_SERVER));
-    
+
     // pass through the incoming response status
     _responseBuilder.get().status(ClientResponse.CONTEXT.get().getStatus());
-    
+
     return "cascading " + ping;
-    
+
   }
 
   @Override

--- a/jareto-demo/src/main/java/at/co/svc/bs/api/IBeanService.java
+++ b/jareto-demo/src/main/java/at/co/svc/bs/api/IBeanService.java
@@ -22,7 +22,7 @@ import at.co.svc.jareto.server.exceptions.ServiceAppExceptionMapper;
 public interface IBeanService {
 
   public static final String ENDPOINT = "http://localhost:8080/jareto-demo/";
-  
+
   /**
    * Some custom header that the service accepts from the client.
    */
@@ -32,7 +32,7 @@ public interface IBeanService {
    * Test header sent by the client transporting the desired response status code.
    */
   public static final String X_DESIRED_STATUS_FROM_CLIENT = "x-desired-status-from-client";
-  
+
   /**
    * Some custom header that the service returns to the client.
    */
@@ -42,23 +42,23 @@ public interface IBeanService {
    * Some custom header that the service returns to the client via class-level annotation.
    */
   public static final String X_TEST_HEADER_FROM_SERVER_CLASS = "x-test-header-from-server-class";
-  
+
   /**
    * Some custom header that the service returns to the client via method-level annotation.
    */
   public static final String X_TEST_HEADER_FROM_SERVER_METHOD = "x-test-header-from-server-method";
-  
+
   /**
-   * ENDPOINT/v1/ping 
+   * ENDPOINT/v1/ping
    */
   @Path("ping")
   @GET
   @Header(name = IBeanService.X_TEST_HEADER_FROM_SERVER_METHOD, value = "test-method")
   public String ping(@HeaderParam(IBeanService.X_DESIRED_STATUS_FROM_CLIENT) Integer desiredStatus);
-  
+
   /**
    * ENDPOINT/v1/exRte
-   * 
+   *
    * Throws a RuntimeException. Bad if not handled globally (Wildfly returns an HTML page with stack trace).
    */
   @Path("exRte")
@@ -67,7 +67,7 @@ public interface IBeanService {
 
   /**
    * ENDPOINT/v1/exMapped
-   * 
+   *
    * Throws an {@link AppException}, which is mapped by {@link ServiceAppExceptionMapper}.
    */
   @Path("exMapped")
@@ -75,8 +75,17 @@ public interface IBeanService {
   void exMapped() throws AppException;
 
   /**
+   * ENDPOINT/v1/exMappedCustomized
+   *
+   * Throws a customized {@link AppException}, which is mapped by {@link ServiceAppExceptionMapper}.
+   */
+  @Path("exMappedCustomized")
+  @GET
+  void exMappedCustomized() throws AppException;
+
+  /**
    * ENDPOINT/v1/exMappedRte
-   * 
+   *
    * Throws an {@link AppRuntimeException}, which is mapped by {@link ServiceAppExceptionMapper}.
    */
   @Path("exMappedRte")
@@ -92,7 +101,7 @@ public interface IBeanService {
 
   /**
    * ENDPOINT/v1/exMapped
-   * 
+   *
    * Throws an {@link AppException}, which is mapped by {@link ServiceAppExceptionMapper}.
    */
   @Path("cascadeExMapped")
@@ -101,7 +110,7 @@ public interface IBeanService {
 
   /**
    * ENDPOINT/v1/exMappedRte
-   * 
+   *
    * Throws an {@link AppRuntimeException}, which is mapped by {@link ServiceAppExceptionMapper}.
    */
   @Path("cascadeExMappedRte")

--- a/jareto-demo/src/test/java/at/co/svc/bs/BeanServiceTest.java
+++ b/jareto-demo/src/test/java/at/co/svc/bs/BeanServiceTest.java
@@ -22,7 +22,7 @@ import at.co.svc.jareto.common.exceptions.AppRuntimeException;
 public class BeanServiceTest {
 
   private static IBeanService _demoClient;
-  
+
   @BeforeClass
   public static void beforeClass() throws Exception {
     RestClientBuilder builder = RestClientBuilder.newBuilder()
@@ -42,7 +42,7 @@ public class BeanServiceTest {
     Assert.assertEquals("pong", ret);
     Assert.assertEquals(desiredStatus, ClientResponse.CONTEXT.get().getStatus());
   }
-  
+
   /**
    * Tests transfer of HTTP headers.
    */
@@ -92,7 +92,26 @@ public class BeanServiceTest {
       Assert.assertEquals(expected.getStatus(), ClientResponse.CONTEXT.get().getStatus());
     }
   }
-  
+
+  /**
+   * Tests mapping of a customized AppException (checked exception).
+   */
+  @Test
+  public void exMappedCustomized() throws Exception {
+    try {
+      _demoClient.exMappedCustomized();
+      Assert.fail("expecting exception");
+    }
+    catch (AppException e) {
+      AppException expected = BeanExceptionFactory.createBeanException();
+      Assert.assertEquals(expected.getData().getCode() + "c", e.getData().getCode());
+      Assert.assertEquals(expected.getData().getText() + " customized", e.getData().getText());
+      Assert.assertEquals(BeanFactory.createBean(), ((AppExceptionDataWithBean) e.getData()).getBean());
+      Assert.assertEquals(expected.getStatus(), e.getStatus());
+      Assert.assertEquals(expected.getStatus(), ClientResponse.CONTEXT.get().getStatus());
+    }
+  }
+
   /**
    * Tests mapping of an AppRuntimeException (runtime exception).
    */
@@ -111,7 +130,7 @@ public class BeanServiceTest {
       Assert.assertEquals(expected.getStatus(), ClientResponse.CONTEXT.get().getStatus());
     }
   }
-  
+
   /**
    * Tests a "cascading" request (i.e., one that triggers another request by the server).
    * Makes sure that transfer of HTTP status and headers also works for a client that is used
@@ -119,13 +138,13 @@ public class BeanServiceTest {
    */
   @Test
   public void cascade() throws Exception {
-    
+
     String headerValue = "test-header-value-from-client";
     int desiredStatus = 202;
-    
+
     ClientRequestHeaders.addHeader(IBeanService.X_TEST_HEADER_FROM_CLIENT, headerValue);
     String ret = _demoClient.cascade(desiredStatus);
-    
+
     Assert.assertEquals("cascading pong", ret);
     Assert.assertEquals(desiredStatus, ClientResponse.CONTEXT.get().getStatus());
     Assert.assertEquals(headerValue, ClientResponse.CONTEXT.get().getHeaderString(IBeanService.X_TEST_HEADER_FROM_SERVER));

--- a/jareto-server/src/main/java/at/co/svc/jareto/server/exceptions/WebApplicationExceptionFactory.java
+++ b/jareto-server/src/main/java/at/co/svc/jareto/server/exceptions/WebApplicationExceptionFactory.java
@@ -8,38 +8,39 @@ import javax.ws.rs.core.Response;
 import at.co.svc.jareto.common.exceptions.AppExceptionData;
 import at.co.svc.jareto.common.exceptions.AppRuntimeException;
 import at.co.svc.jareto.common.exceptions.IAppException;
+import at.co.svc.jareto.server.meta.ServiceResponseFilter;
 
-// Test comment
 /**
  * Factory for creating {@link WebApplicationException} from other exceptions.
  */
 public class WebApplicationExceptionFactory {
 
-  private static IServiceExceptionCustomizer _customizer = new IServiceExceptionCustomizer() {
-  };
-  private static ThreadLocal<IServiceExceptionCustomizer> _threadLocalCustumizer = new ThreadLocal<>();
+  private static IServiceExceptionCustomizer _customizer = new IServiceExceptionCustomizer() { };
+  private static ThreadLocal<IServiceExceptionCustomizer> _threadLocalCustomizer = new ThreadLocal<>();
 
   /**
-   * Registers a customizer to be used when mapping exceptions to wire data.
+   * Registers a static, global customizer to be used when mapping exceptions to wire data.
+   * Use {@link WebApplicationExceptionFactory#registerCustomizerThreadLocal(IServiceExceptionCustomizer)} instead if Jareto
+   * is installed as application server module, and used for multiple applications with different customizers.
    */
   public static void registerCustomizer(IServiceExceptionCustomizer customizer) {
     _customizer = customizer;
   }
 
   /**
-   * Registers a customizer to be used when mapping exceptions to wire data. Uses a {@link ThreadLocal} to ensure the right customer
-   * is used when sharing Jareto in a module over many applications. <br/>
-   * Fore save useage use {@link WebApplicationExceptionFactory#removeCustomizerThreadLocal()} after the request is done.
+   * Registers a customizer to be used when mapping exceptions to wire data. Uses a {@link ThreadLocal} to ensure the right
+   * customizer is used when sharing Jareto in an application server module over many applications.
+   * Thread-local clean-up is performed automatically by {@link ServiceResponseFilter}.
    */
   public static void registerCustomizerThreadLocal(IServiceExceptionCustomizer customizer) {
-    _threadLocalCustumizer.set(customizer);
+    _threadLocalCustomizer.set(customizer);
   }
 
   /**
    * Removes the customizer for exception mapping from the {@link ThreadLocal}.
    */
   public static void removeCustomizerThreadLocal() {
-    _threadLocalCustumizer.remove();
+    _threadLocalCustomizer.remove();
   }
 
   /**
@@ -48,8 +49,7 @@ public class WebApplicationExceptionFactory {
   public static WebApplicationException createWae(IAppException ex) {
     IServiceExceptionCustomizer customizer = getCustomizer();
     customizer.appException(ex);
-    return new WebApplicationException(
-        Response
+    return new WebApplicationException(Response
             .status(ex.getStatus())
             .entity(ex.getData())
             .header(IAppException.HEADER_ERROR_TYPE, ex.getClass().getName())
@@ -70,8 +70,7 @@ public class WebApplicationExceptionFactory {
   public static WebApplicationException createWaeForRte(RuntimeException ex) {
     IServiceExceptionCustomizer customizer = getCustomizer();
     customizer.runtimeException(ex);
-    return new WebApplicationException(
-        Response
+    return new WebApplicationException(Response
             .status(customizer.getUnexpectedStatus())
             .entity(new AppExceptionData(
                 customizer.getUnexpectedCode(),
@@ -89,8 +88,7 @@ public class WebApplicationExceptionFactory {
   public static WebApplicationException createWaeForClientError(ClientErrorException ex) {
     IServiceExceptionCustomizer customizer = getCustomizer();
     customizer.clientErrorException(ex);
-    return new WebApplicationException(
-        Response
+    return new WebApplicationException(Response
             .status(customizer.getClientErrorStatus(ex.getResponse().getStatus()))
             .entity(new AppExceptionData(
                 customizer.getClientErrorCode(),
@@ -103,10 +101,10 @@ public class WebApplicationExceptionFactory {
   }
 
   /**
-   * Takes the thread-local custumizer if one is set, otherwise defaults to the static customizer.
+   * Takes the thread-local customizer if one is set, otherwise defaults to the static customizer.
    */
   private static IServiceExceptionCustomizer getCustomizer() {
-    IServiceExceptionCustomizer customizer = _threadLocalCustumizer.get();
+    IServiceExceptionCustomizer customizer = _threadLocalCustomizer.get();
     if (customizer != null) {
       return customizer;
     }

--- a/jareto-server/src/main/java/at/co/svc/jareto/server/exceptions/WebApplicationExceptionFactory.java
+++ b/jareto-server/src/main/java/at/co/svc/jareto/server/exceptions/WebApplicationExceptionFactory.java
@@ -8,6 +8,7 @@ import javax.ws.rs.core.Response;
 import at.co.svc.jareto.common.exceptions.AppExceptionData;
 import at.co.svc.jareto.common.exceptions.AppRuntimeException;
 import at.co.svc.jareto.common.exceptions.IAppException;
+import at.co.svc.jareto.server.meta.ServiceResponseFilter;
 
 /**
  * Factory for creating {@link WebApplicationException} from other exceptions.
@@ -15,66 +16,101 @@ import at.co.svc.jareto.common.exceptions.IAppException;
 public class WebApplicationExceptionFactory {
 
   private static IServiceExceptionCustomizer _customizer = new IServiceExceptionCustomizer() { };
-  
+  private static ThreadLocal<IServiceExceptionCustomizer> _threadLocalCustomizer = new ThreadLocal<>();
+
   /**
-   * Registers a customizer to be used when mapping exceptions to wire data.
+   * Registers a static, global customizer to be used when mapping exceptions to wire data.
+   * Use {@link WebApplicationExceptionFactory#registerCustomizerThreadLocal(IServiceExceptionCustomizer)} instead if Jareto
+   * is installed as application server module, and used for multiple applications with different customizers.
    */
   public static void registerCustomizer(IServiceExceptionCustomizer customizer) {
     _customizer = customizer;
   }
-  
+
+  /**
+   * Registers a customizer to be used when mapping exceptions to wire data. Uses a {@link ThreadLocal} to ensure the right
+   * customizer is used when sharing Jareto in an application server module over many applications.
+   * Thread-local clean-up is performed automatically by {@link ServiceResponseFilter}.
+   */
+  public static void registerCustomizerThreadLocal(IServiceExceptionCustomizer customizer) {
+    _threadLocalCustomizer.set(customizer);
+  }
+
+  /**
+   * Removes the customizer for exception mapping from the {@link ThreadLocal}.
+   */
+  public static void removeCustomizerThreadLocal() {
+    _threadLocalCustomizer.remove();
+  }
+
   /**
    * Creates a WebApplicationException from the given AppException.
    */
   public static WebApplicationException createWae(IAppException ex) {
-    _customizer.appException(ex);
+    IServiceExceptionCustomizer customizer = getCustomizer();
+    customizer.appException(ex);
     return new WebApplicationException(Response
-        .status(ex.getStatus())
-        .entity(ex.getData())
-        .header(IAppException.HEADER_ERROR_TYPE, ex.getClass().getName())
-        // transporting all the exception data via headers may appear lean at first, but has disadvantages:
-        // - you might need structured data in the future, which is better expressed with JSON
-        // - data extraction on the client side is a bit nicer with using Java accessors instead of header key strings
-        // - when no entity is provided in the response, JBoss logs the whole stack trace;
-        //   you would have to provide an exception mapper that catches the exception and converts it
-        //   into a regular response
-        .header(IAppException.HEADER_ERROR_ENTITY_TYPE, ex.getData().getClass().getName())
-        .type(MediaType.APPLICATION_JSON)
-        .build());
+            .status(ex.getStatus())
+            .entity(ex.getData())
+            .header(IAppException.HEADER_ERROR_TYPE, ex.getClass().getName())
+            // transporting all the exception data via headers may appear lean at first, but has disadvantages:
+            // - you might need structured data in the future, which is better expressed with JSON
+            // - data extraction on the client side is a bit nicer with using Java accessors instead of header key strings
+            // - when no entity is provided in the response, JBoss logs the whole stack trace;
+            // you would have to provide an exception mapper that catches the exception and converts it
+            // into a regular response
+            .header(IAppException.HEADER_ERROR_ENTITY_TYPE, ex.getData().getClass().getName())
+            .type(MediaType.APPLICATION_JSON)
+            .build());
   }
 
   /**
    * Creates a WebApplicationException from the given RuntimeException.
    */
   public static WebApplicationException createWaeForRte(RuntimeException ex) {
-    _customizer.runtimeException(ex);
+    IServiceExceptionCustomizer customizer = getCustomizer();
+    customizer.runtimeException(ex);
     return new WebApplicationException(Response
-      .status(_customizer.getUnexpectedStatus())
-      .entity(new AppExceptionData(
-        _customizer.getUnexpectedCode(), 
-        _customizer.getUnexpectedDetailCode(), 
-        _customizer.getUnexpectedText()))      
-      .header(IAppException.HEADER_ERROR_TYPE, AppRuntimeException.class.getName())
-      .header(IAppException.HEADER_ERROR_ENTITY_TYPE, AppExceptionData.class.getName())
-      .type(MediaType.APPLICATION_JSON)
-      .build());
+            .status(customizer.getUnexpectedStatus())
+            .entity(new AppExceptionData(
+                customizer.getUnexpectedCode(),
+                customizer.getUnexpectedDetailCode(),
+                customizer.getUnexpectedText()))
+            .header(IAppException.HEADER_ERROR_TYPE, AppRuntimeException.class.getName())
+            .header(IAppException.HEADER_ERROR_ENTITY_TYPE, AppExceptionData.class.getName())
+            .type(MediaType.APPLICATION_JSON)
+            .build());
   }
-  
+
   /**
    * Creates a WebApplicationException from the given ClientErrorException.
    */
   public static WebApplicationException createWaeForClientError(ClientErrorException ex) {
-    _customizer.clientErrorException(ex);
+    IServiceExceptionCustomizer customizer = getCustomizer();
+    customizer.clientErrorException(ex);
     return new WebApplicationException(Response
-      .status(_customizer.getClientErrorStatus(ex.getResponse().getStatus()))
-      .entity(new AppExceptionData(
-        _customizer.getClientErrorCode(),
-        _customizer.getClientErrorDetailCode(), 
-        _customizer.getClientErrorText()))
-      .header(IAppException.HEADER_ERROR_TYPE, AppRuntimeException.class.getName())
-      .header(IAppException.HEADER_ERROR_ENTITY_TYPE, AppExceptionData.class.getName())
-      .type(MediaType.APPLICATION_JSON)
-      .build());
+            .status(customizer.getClientErrorStatus(ex.getResponse().getStatus()))
+            .entity(new AppExceptionData(
+                customizer.getClientErrorCode(),
+                customizer.getClientErrorDetailCode(),
+                customizer.getClientErrorText()))
+            .header(IAppException.HEADER_ERROR_TYPE, AppRuntimeException.class.getName())
+            .header(IAppException.HEADER_ERROR_ENTITY_TYPE, AppExceptionData.class.getName())
+            .type(MediaType.APPLICATION_JSON)
+            .build());
   }
-  
+
+  /**
+   * Takes the thread-local customizer if one is set, otherwise defaults to the static customizer.
+   */
+  private static IServiceExceptionCustomizer getCustomizer() {
+    IServiceExceptionCustomizer customizer = _threadLocalCustomizer.get();
+    if (customizer != null) {
+      return customizer;
+    }
+    else {
+      return _customizer;
+    }
+  }
+
 }

--- a/jareto-server/src/main/java/at/co/svc/jareto/server/exceptions/WebApplicationExceptionFactory.java
+++ b/jareto-server/src/main/java/at/co/svc/jareto/server/exceptions/WebApplicationExceptionFactory.java
@@ -15,7 +15,9 @@ import at.co.svc.jareto.common.exceptions.IAppException;
  */
 public class WebApplicationExceptionFactory {
 
-  private static IServiceExceptionCustomizer _customizer = new IServiceExceptionCustomizer() { };
+  private static IServiceExceptionCustomizer _customizer = new IServiceExceptionCustomizer() {
+  };
+  private static ThreadLocal<IServiceExceptionCustomizer> _threadLocalCustumizer = new ThreadLocal<>();
 
   /**
    * Registers a customizer to be used when mapping exceptions to wire data.
@@ -25,57 +27,92 @@ public class WebApplicationExceptionFactory {
   }
 
   /**
+   * Registers a customizer to be used when mapping exceptions to wire data. Uses a {@link ThreadLocal} to ensure the right customer
+   * is used when sharing Jareto in a module over many applications. <br/>
+   * Fore save useage use {@link WebApplicationExceptionFactory#removeCustomizerThreadLocal()} after the request is done.
+   */
+  public static void registerCustomizerThreadLocal(IServiceExceptionCustomizer customizer) {
+    _threadLocalCustumizer.set(customizer);
+  }
+
+  /**
+   * Removes the customizer for exception mapping from the {@link ThreadLocal}.
+   */
+  public static void removeCustomizerThreadLocal() {
+    _threadLocalCustumizer.remove();
+  }
+
+  /**
    * Creates a WebApplicationException from the given AppException.
    */
   public static WebApplicationException createWae(IAppException ex) {
-    _customizer.appException(ex);
-    return new WebApplicationException(Response
-        .status(ex.getStatus())
-        .entity(ex.getData())
-        .header(IAppException.HEADER_ERROR_TYPE, ex.getClass().getName())
-        // transporting all the exception data via headers may appear lean at first, but has disadvantages:
-        // - you might need structured data in the future, which is better expressed with JSON
-        // - data extraction on the client side is a bit nicer with using Java accessors instead of header key strings
-        // - when no entity is provided in the response, JBoss logs the whole stack trace;
-        //   you would have to provide an exception mapper that catches the exception and converts it
-        //   into a regular response
-        .header(IAppException.HEADER_ERROR_ENTITY_TYPE, ex.getData().getClass().getName())
-        .type(MediaType.APPLICATION_JSON)
-        .build());
+    IServiceExceptionCustomizer customizer = getCustomizer();
+    customizer.appException(ex);
+    return new WebApplicationException(
+        Response
+            .status(ex.getStatus())
+            .entity(ex.getData())
+            .header(IAppException.HEADER_ERROR_TYPE, ex.getClass().getName())
+            // transporting all the exception data via headers may appear lean at first, but has disadvantages:
+            // - you might need structured data in the future, which is better expressed with JSON
+            // - data extraction on the client side is a bit nicer with using Java accessors instead of header key strings
+            // - when no entity is provided in the response, JBoss logs the whole stack trace;
+            // you would have to provide an exception mapper that catches the exception and converts it
+            // into a regular response
+            .header(IAppException.HEADER_ERROR_ENTITY_TYPE, ex.getData().getClass().getName())
+            .type(MediaType.APPLICATION_JSON)
+            .build());
   }
 
   /**
    * Creates a WebApplicationException from the given RuntimeException.
    */
   public static WebApplicationException createWaeForRte(RuntimeException ex) {
-    _customizer.runtimeException(ex);
-    return new WebApplicationException(Response
-      .status(_customizer.getUnexpectedStatus())
-      .entity(new AppExceptionData(
-        _customizer.getUnexpectedCode(),
-        _customizer.getUnexpectedDetailCode(),
-        _customizer.getUnexpectedText()))
-      .header(IAppException.HEADER_ERROR_TYPE, AppRuntimeException.class.getName())
-      .header(IAppException.HEADER_ERROR_ENTITY_TYPE, AppExceptionData.class.getName())
-      .type(MediaType.APPLICATION_JSON)
-      .build());
+    IServiceExceptionCustomizer customizer = getCustomizer();
+    customizer.runtimeException(ex);
+    return new WebApplicationException(
+        Response
+            .status(customizer.getUnexpectedStatus())
+            .entity(new AppExceptionData(
+                customizer.getUnexpectedCode(),
+                customizer.getUnexpectedDetailCode(),
+                customizer.getUnexpectedText()))
+            .header(IAppException.HEADER_ERROR_TYPE, AppRuntimeException.class.getName())
+            .header(IAppException.HEADER_ERROR_ENTITY_TYPE, AppExceptionData.class.getName())
+            .type(MediaType.APPLICATION_JSON)
+            .build());
   }
 
   /**
    * Creates a WebApplicationException from the given ClientErrorException.
    */
   public static WebApplicationException createWaeForClientError(ClientErrorException ex) {
-    _customizer.clientErrorException(ex);
-    return new WebApplicationException(Response
-      .status(_customizer.getClientErrorStatus(ex.getResponse().getStatus()))
-      .entity(new AppExceptionData(
-        _customizer.getClientErrorCode(),
-        _customizer.getClientErrorDetailCode(),
-        _customizer.getClientErrorText()))
-      .header(IAppException.HEADER_ERROR_TYPE, AppRuntimeException.class.getName())
-      .header(IAppException.HEADER_ERROR_ENTITY_TYPE, AppExceptionData.class.getName())
-      .type(MediaType.APPLICATION_JSON)
-      .build());
+    IServiceExceptionCustomizer customizer = getCustomizer();
+    customizer.clientErrorException(ex);
+    return new WebApplicationException(
+        Response
+            .status(customizer.getClientErrorStatus(ex.getResponse().getStatus()))
+            .entity(new AppExceptionData(
+                customizer.getClientErrorCode(),
+                customizer.getClientErrorDetailCode(),
+                customizer.getClientErrorText()))
+            .header(IAppException.HEADER_ERROR_TYPE, AppRuntimeException.class.getName())
+            .header(IAppException.HEADER_ERROR_ENTITY_TYPE, AppExceptionData.class.getName())
+            .type(MediaType.APPLICATION_JSON)
+            .build());
+  }
+
+  /**
+   * Takes the thread-local custumizer if one is set, otherwise defaults to the static customizer.
+   */
+  private static IServiceExceptionCustomizer getCustomizer() {
+    IServiceExceptionCustomizer customizer = _threadLocalCustumizer.get();
+    if (customizer != null) {
+      return customizer;
+    }
+    else {
+      return _customizer;
+    }
   }
 
 }

--- a/jareto-server/src/main/java/at/co/svc/jareto/server/exceptions/WebApplicationExceptionFactory.java
+++ b/jareto-server/src/main/java/at/co/svc/jareto/server/exceptions/WebApplicationExceptionFactory.java
@@ -9,20 +9,21 @@ import at.co.svc.jareto.common.exceptions.AppExceptionData;
 import at.co.svc.jareto.common.exceptions.AppRuntimeException;
 import at.co.svc.jareto.common.exceptions.IAppException;
 
+// Test comment
 /**
  * Factory for creating {@link WebApplicationException} from other exceptions.
  */
 public class WebApplicationExceptionFactory {
 
   private static IServiceExceptionCustomizer _customizer = new IServiceExceptionCustomizer() { };
-  
+
   /**
    * Registers a customizer to be used when mapping exceptions to wire data.
    */
   public static void registerCustomizer(IServiceExceptionCustomizer customizer) {
     _customizer = customizer;
   }
-  
+
   /**
    * Creates a WebApplicationException from the given AppException.
    */
@@ -51,15 +52,15 @@ public class WebApplicationExceptionFactory {
     return new WebApplicationException(Response
       .status(_customizer.getUnexpectedStatus())
       .entity(new AppExceptionData(
-        _customizer.getUnexpectedCode(), 
-        _customizer.getUnexpectedDetailCode(), 
-        _customizer.getUnexpectedText()))      
+        _customizer.getUnexpectedCode(),
+        _customizer.getUnexpectedDetailCode(),
+        _customizer.getUnexpectedText()))
       .header(IAppException.HEADER_ERROR_TYPE, AppRuntimeException.class.getName())
       .header(IAppException.HEADER_ERROR_ENTITY_TYPE, AppExceptionData.class.getName())
       .type(MediaType.APPLICATION_JSON)
       .build());
   }
-  
+
   /**
    * Creates a WebApplicationException from the given ClientErrorException.
    */
@@ -69,12 +70,12 @@ public class WebApplicationExceptionFactory {
       .status(_customizer.getClientErrorStatus(ex.getResponse().getStatus()))
       .entity(new AppExceptionData(
         _customizer.getClientErrorCode(),
-        _customizer.getClientErrorDetailCode(), 
+        _customizer.getClientErrorDetailCode(),
         _customizer.getClientErrorText()))
       .header(IAppException.HEADER_ERROR_TYPE, AppRuntimeException.class.getName())
       .header(IAppException.HEADER_ERROR_ENTITY_TYPE, AppExceptionData.class.getName())
       .type(MediaType.APPLICATION_JSON)
       .build());
   }
-  
+
 }


### PR DESCRIPTION
Allow the user to register an exception customizer as thread local. Prevents leakage of customizers across different applications if Jareto is installed as application server module.